### PR TITLE
Improve error visibility

### DIFF
--- a/ci/dockerfiles/tests/start-docker.sh
+++ b/ci/dockerfiles/tests/start-docker.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 # Ensure that all nodes in /dev/mapper correspond to mapped devices currently loaded by the device-mapper kernel driver
 dmsetup mknodes
 


### PR DESCRIPTION
I was missing the `dmsetup` executable and the whole script still ran.

I hope that the script doesn't expect errors or undefined variables in some cases...